### PR TITLE
Start tracking our own dataservices

### DIFF
--- a/qcom.xml
+++ b/qcom.xml
@@ -21,7 +21,7 @@
 <!-- Vendor -->
   <project name="vendor_codeaurora_telephony" path="vendor/codeaurora/telephony" remote="crd" />
   <project name="LineageOS/android_vendor_qcom_opensource_cryptfs_hw" path="vendor/qcom/opensource/cryptfs_hw" remote="github" revision="lineage-15.0" />
-  <project name="platform/vendor/qcom-opensource/dataservices" path="vendor/qcom/opensource/dataservices" remote="qcom" />
+  <project name="vendor_qcom_opensource_dataservices" path="vendor/qcom/opensource/dataservices" remote="crd" />
   <project name="vendor_qcom_opensource_fm" path="vendor/qcom/opensource/fm" remote="crd" />
   <project name="system_qcom" path="vendor/qcom/opensource/softap" remote="crd" />
 </manifest>


### PR DESCRIPTION
This is required to allow to use an in-device dataservices instead of the caf one

Of course is also needed to create the repo in Cardinal-AOSP org, here an example with the needed edits

https://github.com/DD3Boh/vendor_qcom_opensource_dataservices